### PR TITLE
Fixed spelling for xml-proprietary and removed trailing spaces.

### DIFF
--- a/apply_headers
+++ b/apply_headers
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # Author    Mike Purvis <mpurvis@clearpathrobotics.com>
 # Copyright (c) 2013, Clearpath Robotics, Inc., All rights reserved.
@@ -24,7 +24,7 @@
 if [[ "$#" == "0" ]]; then
   echo "Usages:"
   echo "  apply_headers file1 file2 .."
-  echo "  apply_headers --recurse" 
+  echo "  apply_headers --recurse"
   exit 1
 fi
 
@@ -64,7 +64,7 @@ for filename in ${filenames}; do
     # Executable file, get type from shebang
     shebang=$(head -n 1 "$filename")
     contents=$(tail -n +2 "$filename")
-    if [[ "$shebang" == *python* ]]; then 
+    if [[ "$shebang" == *python* ]]; then
       extension=py
       echo "Applying header for python shebang to file: $filename"
     elif [[ "$shebang" == *bash* ]]; then
@@ -80,18 +80,18 @@ for filename in ${filenames}; do
     contents=$(< "$filename")
     header_filename="$HEADERS_PATH/$extension"
     if [[ ! -f "$header_filename" ]]; then
-      echo "No header found for type [$extension] for file: $filename" 
+      echo "No header found for type [$extension] for file: $filename"
       continue
     fi
-    echo "Applying new header of type [$extension] to file: $filename" 
+    echo "Applying new header of type [$extension] to file: $filename"
   fi
- 
+
   # Template configuration
   cat << EOF > /tmp/header_config.py
 user="$(git config --get user.name)"
 email="$(git config --get user.email)"
 year="$(date +%Y)"
-filename="$base_filename"  
+filename="$base_filename"
 EOF
 
 header=$(empy -F/tmp/header_config.py "$header_filename")

--- a/bsd/bash
+++ b/bsd/bash
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # Author    @(user) <@(email)>
 # Copyright (c) @(year), Clearpath Robotics, Inc., All rights reserved.

--- a/bsd/py
+++ b/bsd/py
@@ -1,4 +1,4 @@
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # @@author    @(user) <@(email)>
 # @@copyright (c) @(year), Clearpath Robotics, Inc., All rights reserved.

--- a/prop/py
+++ b/prop/py
@@ -1,4 +1,4 @@
-# Software License Agreement (proprietary) 
+# Software License Agreement (proprietary)
 #
 # @@author    @(user) <@(email)>
 # @@copyright (c) @(year), Clearpath Robotics, Inc., All rights reserved.

--- a/prop/xml
+++ b/prop/xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Software License Agreement (prorietary)
+Software License Agreement (proprietary)
 
 \file      @(filename)
 \authors   @(user) <@(email)>

--- a/setup.bash
+++ b/setup.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # Author    Mike Purvis <mpurvis@clearpathrobotics.com>
 # Copyright (c) 2013, Clearpath Robotics, Inc., All rights reserved.

--- a/use_headers
+++ b/use_headers
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Software License Agreement (BSD) 
+# Software License Agreement (BSD)
 #
 # Author    Mike Purvis <mpurvis@clearpathrobotics.com>
 # Copyright (c) 2013, Clearpath Robotics, Inc., All rights reserved.


### PR DESCRIPTION
I noticed a spelling mistake for xml files so I fixed it and i didn't like the trailing spaces so I removed them.

I tested with proprietary: xml,py,cpp,h,launch and it is applying correctly.